### PR TITLE
Add Username, Client ID and Peer ID to Client List

### DIFF
--- a/openvpn_status/models.py
+++ b/openvpn_status/models.py
@@ -26,6 +26,9 @@ class Client(object):
         u'Bytes Received', input_type=parse_filesize)
     bytes_sent = LabelProperty(u'Bytes Sent', input_type=parse_filesize)
     connected_since = LabelProperty(u'Connected Since', input_type=parse_time)
+    username = LabelProperty(u'Username')
+    client_id = LabelProperty(u'Client ID', input_type=int)
+    peer_id = LabelProperty(u'Peer ID', input_type=int)
 
 
 @name_descriptors

--- a/tests/data/openvpn-status.txt
+++ b/tests/data/openvpn-status.txt
@@ -1,11 +1,11 @@
 OpenVPN CLIENT LIST
 Updated,Thu Jun 18 08:12:15 2015
-Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since
-foo@example.com,10.10.10.10:49502,334948,1973012,Thu Jun 18 04:23:03 2015
-foo@example.com,10.10.10.10:49503,334948,1973012,Thu Jun 18 04:23:03 2015
-bar@example.com,10.10.10.10:64169,1817262,28981224,Thu Jun 18 04:08:39 2015
-baz@example.com,10.10.10.10:63414,111183,1202203,Thu Jun 18 07:57:25 2015
-tap@example.com,10.0.0.100:55712,0,0,Thu Oct 19 20:14:19 2017
+Common Name,Real Address,Bytes Received,Bytes Sent,Connected Since,Username,Client ID,Peer ID
+foo@example.com,10.10.10.10:49502,334948,1973012,Thu Jun 18 04:23:03 2015,issac,0,0
+foo@example.com,10.10.10.10:49503,334948,1973012,Thu Jun 18 04:23:03 2015,issac,1,0
+bar@example.com,10.10.10.10:64169,1817262,28981224,Thu Jun 18 04:08:39 2015,issac,2,0
+baz@example.com,10.10.10.10:63414,111183,1202203,Thu Jun 18 07:57:25 2015,issac,3,0
+tap@example.com,10.0.0.100:55712,0,0,Thu Oct 19 20:14:19 2017,issac,4,0
 ROUTING TABLE
 Virtual Address,Common Name,Real Address,Last Ref
 192.168.255.118,baz@example.com,10.10.10.10:63414,Thu Jun 18 08:12:09 2015

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,6 +51,9 @@ def test_client():
     assert getattr(client, 'bytes_received', None) is None
     assert getattr(client, 'bytes_sent', None) is None
     assert getattr(client, 'connected_since', None) is None
+    assert getattr(client, 'username', None) is None
+    assert getattr(client, 'client_id', None) is None
+    assert getattr(client, 'peer_id', None) is None
 
     client.bytes_received = 532895
     assert client.bytes_received.humanize() == u'532.9 kB'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,6 +38,8 @@ def test_parser(openvpn_status):
     assert client.connected_since == datetime.datetime(2015, 6, 18, 4, 23, 3)
     assert client.bytes_received == 334948
     assert client.bytes_sent == 1973012
+    assert client.username == u'issac'
+    assert client.client_id == 0
 
     tun_routing = status.routing_table[u'192.168.255.134']
     assert isinstance(tun_routing.virtual_address, ipaddress.IPv4Address)


### PR DESCRIPTION
The biggest caveat here is that I don't know what version of openvpn these fields were added in, but I require the client ID for my application so I prepared this patch.