### PR TITLE
make use of the newer format for dates

### DIFF
--- a/openvpn_status/utils.py
+++ b/openvpn_status/utils.py
@@ -10,7 +10,8 @@ from humanize.filesize import naturalsize
 from netaddr import EUI, mac_unix
 
 
-DATETIME_FORMAT_OPENVPN = u'%a %b %d %H:%M:%S %Y'
+DATETIME_FORMAT_OPENVPN_V2_5 = u'%Y-%m-%d %H:%M:%S'
+DATETIME_FORMAT_OPENVPN_V2_4 = u'%a %b %d %H:%M:%S %Y'
 RE_VIRTUAL_ADDR_MAC = re.compile(
     u'^{0}:{0}:{0}:{0}:{0}:{0}$'.format(u'[a-f0-9]{2}'), re.I)
 RE_VIRTUAL_ADDR_NETWORK = re.compile(u'/(\\d{1,3})$')
@@ -21,7 +22,11 @@ def parse_time(time):
     """Parses date and time from input string in OpenVPN logging format."""
     if isinstance(time, datetime.datetime):
         return time
-    return datetime.datetime.strptime(time, DATETIME_FORMAT_OPENVPN)
+    try:
+        # firs use the newer format
+        return datetime.datetime.strptime(time, DATETIME_FORMAT_OPENVPN_V2_5)
+    except:
+        return datetime.datetime.strptime(time, DATETIME_FORMAT_OPENVPN_V2_4)
 
 
 def parse_peer(peer):


### PR DESCRIPTION
Since with new openvpn 2.5 date format has changed.

This fix allows for using both date formats.