### PR TITLE
OpenVPN-2.5+ and onwards has a new datetime format. Old one won't work

### DIFF
--- a/openvpn_status/utils.py
+++ b/openvpn_status/utils.py
@@ -10,7 +10,7 @@ from humanize.filesize import naturalsize
 from netaddr import EUI, mac_unix
 
 
-DATETIME_FORMAT_OPENVPN = u'%a %b %d %H:%M:%S %Y'
+DATETIME_FORMAT_OPENVPN = u'%Y-%m-%d %H:%M:%S'
 RE_VIRTUAL_ADDR_MAC = re.compile(
     u'^{0}:{0}:{0}:{0}:{0}:{0}$'.format(u'[a-f0-9]{2}'), re.I)
 RE_VIRTUAL_ADDR_NETWORK = re.compile(u'/(\\d{1,3})$')


### PR DESCRIPTION
The old datetime format doesn't work anymore on newer versions of openVPN-2.5+.
When using `openvpn-api` for example get_status() function it'll give us an error in datefomats
suggesting how it should be.
